### PR TITLE
Skip account deleted and quiver notices

### DIFF
--- a/okc_arrow_fetcher.py
+++ b/okc_arrow_fetcher.py
@@ -180,7 +180,7 @@ class ArrowFetcher:
         for message in soup.find('ul', {'id': 'thread'}).findAll('li'):
             message_type = re.sub(r'_.*$', '', message.get('id', 'unknown'))
             body_contents = message.find('div', 'message_body')
-            if body_contents:
+            if body_contents and message_type != 'deleted' and message_type != 'quiver':
                 body = self._strip_tags(body_contents.renderContents()).renderContents().strip()
                 for find, replace in self.encoding_pairs:
                     body = body.replace(find, replace)


### PR DESCRIPTION
Deleted and quiver notices do not contain relevant user messages. The meta data that the user selected you as a quiver match, or has deleted their account, may be interesting in the bigger picture though,
