### PR TITLE
The message counterpart is now wrapped in a span with an inner anchor/link

### DIFF
--- a/okc_arrow_fetcher.py
+++ b/okc_arrow_fetcher.py
@@ -170,7 +170,7 @@ class ArrowFetcher:
         except AttributeError:
             subject = unicode('')
         try:
-            other_user = soup.find('a', {'class': 'buddyname'}).contents[0]
+            other_user = soup.find('span', {'class': 'buddyname'}).find('a').contents[0]
         except AttributeError:
             try:
                 # messages from OkCupid itself are a special case


### PR DESCRIPTION
Otherwise name would be empty.
