### PR TITLE
Add python virtual environment, strict package versions, wrapper script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ pip-log.txt
 
 #Mr Developer
 .mr.developer.cfg
+
+# OKCMD local virtual environment
+.okcmd-virtualenv/

--- a/README.textile
+++ b/README.textile
@@ -6,9 +6,9 @@ A script for downloading your sent and received "OkCupid":https://www.okcupid.co
 
 h2. Usage
 
-To use it, run it from the command line like this:
+Requires @python2.7@, "@virtualenv@":https://virtualenv.pypa.io/ and "@pip@":https://pip.pypa.io/. To use it, run it from the command line like this:
 
-bc. python okc_arrow_fetcher.py -u your_username -p your_password -f 'output_message_file.txt'
+bc. okcmd -u your_username -p your_password -f 'output_message_file.txt'
 
 
 h3. Thunderbird
@@ -19,6 +19,8 @@ You can add the @-t@ flag to get the output as a possibly-Thunderbird-compatible
 h3. Advanced usage
 
 @--debug@ shows _a lot_ more output.
+
+The @okcmd@ command uses @python2.7@ and wraps execution in a virtual environment installed using @virtualenv@ and @pip@. If that doesn't work for you, try running @python okc_arrow_fetcher.py@ directly.
 
 
 

--- a/okcmd
+++ b/okcmd
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -e
+
+function req {
+	local program="$1"
+
+	if [[ -z "$(which "$program")" ]];
+	then
+		echo "$program is required" >&2
+		exit 1
+	fi
+}
+
+req python2.7
+req virtualenv
+req pip
+
+
+OKCMD_VENV="${BASH_SOURCE%/*}/.okcmd-virtualenv"
+
+[[ -d "$OKCMD_VENV" ]] || NEEDS_INSTALLATION="true"
+
+if [[ "$NEEDS_INSTALLATION" == "true" ]];
+then
+	# Create new virtualenv directory.
+	virtualenv --python python2.7 --no-site-packages "${OKCMD_VENV}"
+
+	# Just an empty line to group output lines.
+	echo
+fi
+
+# Activate virtual environment.
+source "${OKCMD_VENV}/bin/activate"
+
+if [[ "$NEEDS_INSTALLATION" == "true" ]];
+then
+	# Install python packages/dependencies.
+	pip install --no-deps --requirement requirements.txt
+
+	# Just an empty line to group output lines.
+	echo
+fi
+
+# Download messages.
+python "${BASH_SOURCE%/*}/okc_arrow_fetcher.py" "$@"
+
+# Deactivate virtual environment.
+deactivate

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+BeautifulSoup==3.2.1


### PR DESCRIPTION
Used to lock usage to Python 2.7 and BeautifulSoup 3.2.1. This is to reduce version confusion in error reports, and to be able to keep track of dependency version upgrades. The wrapper script `okcmd` activates the virtual environment in `.okcmd-virtualenv/` as well as installs dependencies -- usage is the same as for `okc_arrow_fetcher.py`.

Requires `python2.7`, `virtualenv` and `pip` in the `$PATH`.

Let me know if `okcmd` works for you and if it can be merged!