### PR TITLE
Alternative login method "autologin link"

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -18,6 +18,8 @@ You can add the @-t@ flag to get the output as a possibly-Thunderbird-compatible
 
 h3. Advanced usage
 
+@--autologin@ can be used instead of @--password@. Supply it with a link that will automatically log you in to OkCupid; you can find these links in emails sent to you from Okcupid. One example is the logotype in top/new matches emails - right click and choose "copy link", then use it with the @--autologin@ argument.
+
 @--debug@ shows _a lot_ more output.
 
 The @okcmd@ command uses @python2.7@ and wraps execution in a virtual environment installed using @virtualenv@ and @pip@. If that doesn't work for you, try running @python okc_arrow_fetcher.py@ directly.


### PR DESCRIPTION
Using the normal username/password combination when to log in to OkCupid might
not work. One theory is that it triggers automatic bot blocking which requires
a captcha to be filled in.

By instead using special links that OkCupid recognizes as secure enough to
automatically log you in, this bot protection can be bypassed. Auto-login
links can be found in emails sent out by OkCupid. One example is the OkCupid
logotype in new/top matches. Copy that link directly from your email, and
use it for the `--autologin` parameter, which then replaces `--password`.