### PR TITLE
Get message thread id (url) from data property

### DIFF
--- a/src/arrow_fetcher.py
+++ b/src/arrow_fetcher.py
@@ -120,7 +120,7 @@ class ArrowFetcher:
                     soup = self._safely_soupify(f)
                     end_pattern = re.compile('&folder=\d\';')
                     threads = [
-                        re.sub(end_pattern, '', li.find('a', {'class': 'open'} )['href'].partition('&folder=')[0])
+                        '/messages?readmsg=true&threadid=' + li['data-threadid']
                         for li in soup.find('ul', {'id': 'messages'}).find_all('li')
                     ]
                     if len(threads) == 0:  # break out of the infinite loop when we reach the end and there are no threads on the page


### PR DESCRIPTION
OKCupid have redesigned the messages/thread/conversation list, and removed links to the page displaying the content of each individual message. Instead messages are loaded in the medium size message box in the lower right corner of the screen, using ajax.

The old message display page (the one harvested by OKCMD) still exists on the server, but perhaps not for long. OKCMD users are encouraged to backup their messages ASAP, in case further design changes are harder to adapt to.